### PR TITLE
sxml : fix memory size to store safely the '\0' after the string

### DIFF
--- a/ext/sxmlc.c
+++ b/ext/sxmlc.c
@@ -1416,7 +1416,7 @@ static int _parse_data_SAX(void* in, const DataSourceType in_type, const SAX_Cal
 		if (*line != NULC && (sax->new_text != NULL || sax->all_event != NULL)) {
 			SXML_CHAR* unhtml = line;
 			if (has_html(line)) {
-				unhtml = __malloc(sx_strlen(line) * sizeof(SXML_CHAR)); /* Allocate for HTML escaping */
+				unhtml = __malloc((sx_strlen(line)+1) * sizeof(SXML_CHAR)); /* Allocate for HTML escaping */
 				if (unhtml == NULL) {
 					if (sax->on_error != NULL && !sax->on_error(PARSE_ERR_MEMORY, sd->line_num, sd))
 						break;


### PR DESCRIPTION
fix crash on xml parser sxml used by xlsx_drone

The _parse_data_SAX alloc a buffer of size strlen(line) for before calling html2str.

html2str create a string with same length of line (or smaller) BUT add a '\0' after the string.

So we need add a +1 on the malloc to avoid valgrind or address sanitizer report or... crash!
see https://github.com/matthieu-labas/sxmlc/pull/23/